### PR TITLE
Add node_modules folder as another express server static files location

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Event HUD</title>
-    <script src="../../node_modules/angular/angular.js"></script>
+    <script src="angular/angular.js"></script>
   </head>
   <body>
     <div ng-app="eventHUD">

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,7 @@ const stub = require('./stubData');
 
 app.use(bodyParser.json());
 app.use(express.static(__dirname + '/../client/dist'));
+app.use(express.static(__dirname + '/../node_modules'));
 app.use('/event', event);
 app.use('/group', group);
 app.use('/user', user);


### PR DESCRIPTION
This should fix the broken staging app, which should currently render as a "Brought to you by the Grazers" heading.