### PR TITLE
Implement websocket interface in app server

### DIFF
--- a/client/src/components/app.component.js
+++ b/client/src/components/app.component.js
@@ -8,5 +8,6 @@
 module.exports = {
   template: `
     <h1>Brought to you by the Grazers!</h1>
+    <message-send />
 `
 };

--- a/client/src/components/app.component.js
+++ b/client/src/components/app.component.js
@@ -8,6 +8,7 @@
 module.exports = {
   template: `
     <h1>Brought to you by the Grazers!</h1>
-    <message-send />
+    <message-send></message-send>
+    <message-display></message-display>
 `
 };

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,3 +1,4 @@
 angular.module('eventHUD').component('app', require('./app.component'));
 angular.module('eventHUD').component('messageSend', require('./messageSend.component'));
+angular.module('eventHUD').component('messageDisplay', require('./messageDisplay.component'));
 //This is a test of the emergency event hud system... this is only a test...relax.. it's okay...you will surive the event.

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,2 +1,3 @@
 angular.module('eventHUD').component('app', require('./app.component'));
+angular.module('eventHUD').component('messageSend', require('./messageSend.component'));
 //This is a test of the emergency event hud system... this is only a test...relax.. it's okay...you will surive the event.

--- a/client/src/components/messageDisplay.component.js
+++ b/client/src/components/messageDisplay.component.js
@@ -1,6 +1,16 @@
 module.exports = {
+  controller: function(websockets) {
+    this.receive = event => {
+      console.log(`Message from the server ${event.data}`);
+      const li = document.createElement('li');
+      li.textContent = event.data;
+      document.getElementById('messages').appendChild(li);
+    };
+    websockets.receive(this.receive);
+  },
   template: `
     <div>
+      <h3>Messages</h3>
       <ul id="messages"></ul>
     </div>
   `

--- a/client/src/components/messageDisplay.component.js
+++ b/client/src/components/messageDisplay.component.js
@@ -1,0 +1,7 @@
+module.exports = {
+  template: `
+    <div>
+      <ul id="messages"></ul>
+    </div>
+  `
+};

--- a/client/src/components/messageSend.component.js
+++ b/client/src/components/messageSend.component.js
@@ -1,0 +1,17 @@
+module.exports = {
+  controller: function(websockets) {
+    this.message = '';
+    this.sendMessage = function() {
+      websockets.send(this.message);
+      this.message = '';
+    };
+  },
+  template: `
+    <div>
+      <form id="send-message-form" ng-submit="$ctrl.sendMessage()">
+        <input id="compose-message" autocomplete="off" ng-model="$ctrl.message"/>
+        <button>Send</button>
+      </form>
+    </div>
+  `
+};

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,3 +1,4 @@
 angular.module('eventHUD', []);
 
 require('./components');
+require('./services');

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -1,0 +1,1 @@
+angular.module('eventHUD').service('websockets', require('./websockets.service'));

--- a/client/src/services/websockets.service.js
+++ b/client/src/services/websockets.service.js
@@ -3,13 +3,11 @@ function websockets() {
 
   this.send = function(message) {
     this.socket.send(message);
-  }
+  };
 
-  this.receive = function() {
-    this.socket.addEventListener('message', event => {
-      console.log(`Message from the server ${event.data}`);
-    });
-  }
+  this.receive = function(callback) {
+    this.socket.addEventListener('message', callback);
+  };
 }
 
 module.exports = websockets;

--- a/client/src/services/websockets.service.js
+++ b/client/src/services/websockets.service.js
@@ -1,0 +1,15 @@
+function websockets() {
+  this.socket = new WebSocket(`ws://${window.location.host}/`);
+
+  this.send = function(message) {
+    this.socket.send(message);
+  }
+
+  this.receive = function() {
+    this.socket.addEventListener('message', event => {
+      console.log(`Message from the server ${event.data}`);
+    });
+  }
+}
+
+module.exports = websockets;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "angular": "^1.6.6",
     "body-parser": "^1.18.2",
-    "express": "^4.16.1"
+    "express": "^4.16.1",
+    "ws": "^3.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/server/event.js
+++ b/server/event.js
@@ -29,21 +29,9 @@ router.route('/:eventId/groups')
   res.status(201).send(newGroupObj);
 });
 
-router.route('/:eventId/messages')
-  .get((req, res) => {
+router.get('/:eventId/messages', (req, res) => {
     const eventId = Number(req.params.eventId);
     res.status(200).send(stub.messages);
-  })
-  .post((req, res) => {
-    const recipients = req.body.toList;
-    const messageSends = recipients.map(recipient => {
-      return {
-        messageId: 5,
-        recipientType: recipient.type,
-        recipientId: recipient.id
-      }
-    });
-    res.status(201).send(messageSends);
   });
 
 router.get('/:eventId/users', (req, res) => {

--- a/server/server.js
+++ b/server/server.js
@@ -21,11 +21,15 @@ app.use('/user', user);
 app.use('/message', message);
 
 wss.on('connection', (ws, req) => {
+  console.log('New client connected');
   ws.on('message', msg => {
     console.log(`Received ${msg}`);
+    wss.clients.forEach(client => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(msg);
+      }
+    });
   });
-
-  ws.send('something');
 });
 
 app.route('/events')

--- a/server/server.js
+++ b/server/server.js
@@ -52,7 +52,7 @@ app.get('/messages', (req, res) => {
 if ( module.parent ) {
   module.exports = app;
 } else {
-  app.listen(port, () => {
+  server.listen(port, () => {
     console.log(`Event HUD server running on port ${port}`);
   });
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1,13 +1,17 @@
 const express = require('express');
 const app = express();
+const server = require('http').Server(app);
 const port = process.env.PORT || '3000';
+
+const WebSocket = require('ws');
+const wss = new WebSocket.Server({ server });
+
 const bodyParser = require('body-parser');
 const event = require('./event');
 const group = require('./group');
 const user = require('./user');
 const message = require('./message');
 const stub = require('./stubData');
-
 app.use(bodyParser.json());
 app.use(express.static(__dirname + '/../client/dist'));
 app.use(express.static(__dirname + '/../node_modules'));
@@ -15,6 +19,14 @@ app.use('/event', event);
 app.use('/group', group);
 app.use('/user', user);
 app.use('/message', message);
+
+wss.on('connection', (ws, req) => {
+  ws.on('message', msg => {
+    console.log(`Received ${msg}`);
+  });
+
+  ws.send('something');
+});
 
 app.route('/events')
   .get((req, res) => {
@@ -42,6 +54,5 @@ if ( module.parent ) {
 } else {
   app.listen(port, () => {
     console.log(`Event HUD server running on port ${port}`);
-  });  
+  });
 }
-


### PR DESCRIPTION
This commit includes the following changes in order to set up a websocket interface in the app server:
- server uses the ws WebSocket library
- ws Nodejs library added as runtime dependency in package.json
- endpoint stub for messages POST removed since we'll be using WebSockets for messages
- client components for message send and display added to test and demo websocket setup
- new Angular service created so that websocket interface can be shared across components

To test this out in your local environment, start the dev server and dev client with "npm run server-dev" and "npm run ng-dev". Run more than one client, type a message in one client and expect to see that message appear on all clients. There is also console logging on the server and client.
