### PR TITLE
Update babelrc in package.json to use Airbnb preset for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",
+    "babel-preset-airbnb": "^2.4.0",
     "babel-register": "^6.7.2",
     "chai": "^4.1.2",
     "eslint": "^4.8.0",
@@ -39,7 +40,7 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      "es2015", "airbnb"
     ]
   }
 }


### PR DESCRIPTION
I'm not sure linting has been completely setup because I haven't been getting linting errors so I looked around some more to see if there is additional setup. This commit adds the Airbnb babel preset.