### PR TITLE
Implement staff messages to only display for membership group

### DIFF
--- a/client/src/components/eventBroadcast.component.js
+++ b/client/src/components/eventBroadcast.component.js
@@ -5,7 +5,7 @@ module.exports = {
   template: `
     <div class="container col-md-7">
       <div class="message-display">
-        <message-display></message-display>
+        <message-display user="$ctrl.user"></message-display>
       </div>
       <div id="send-message-form">
         <message-send user="$ctrl.user"></message-send>

--- a/client/src/components/groupMembership.component.js
+++ b/client/src/components/groupMembership.component.js
@@ -4,7 +4,7 @@ module.exports = {
     group: '<'
   },
   controller(groups) {
-    this.$onChanges = function bound() {
+    this.$onChanges = () => {
       if (this.group) {
         groups.getMembers(this.group.id)
           .then((members) => {

--- a/client/src/components/groupUpdates.component.js
+++ b/client/src/components/groupUpdates.component.js
@@ -1,12 +1,16 @@
 module.exports = {
   bindings: {
+    user: '<',
     group: '<'
   },
   template: `
     <div class="container col-md-7">
       <h3>{{$ctrl.group.name}}</h3>
       <div class="message-display">
-        <message-display group="$ctrl.group"></message-display>
+        <message-display user="$ctrl.user" group="$ctrl.group"></message-display>
+      </div>
+      <div id="send-message-form">
+        <message-send user="$ctrl.user" group="$ctrl.group"></message-send>
       </div>
   </div>
   `

--- a/client/src/components/messageDisplay.component.js
+++ b/client/src/components/messageDisplay.component.js
@@ -21,7 +21,8 @@ module.exports = {
     this.receive = (event) => {
       console.log(`Message from the server ${event.data}`);
       const data = JSON.parse(event.data);
-      if (this.user.role === 'organizer' || data.toIds.includes(this.group.id)) {
+      const isBroadcast = this.user.role === 'organizer' && data.fromId === this.user.id;
+      if (isBroadcast || data.toIds.includes(this.group.id)) {
         const message = this.displayMessage(data);
         document.getElementById('messages').appendChild(message);
       }

--- a/client/src/components/messageDisplay.component.js
+++ b/client/src/components/messageDisplay.component.js
@@ -1,5 +1,6 @@
 module.exports = {
   bindings: {
+    user: '<',
     group: '<'
   },
   controller(websockets) {
@@ -20,7 +21,7 @@ module.exports = {
     this.receive = (event) => {
       console.log(`Message from the server ${event.data}`);
       const data = JSON.parse(event.data);
-      if (!this.group || data.to.includes(String(this.group.id))) {
+      if (this.user.role === 'organizer' || data.toIds.includes(this.group.id)) {
         const message = this.displayMessage(data);
         document.getElementById('messages').appendChild(message);
       }

--- a/client/src/components/messageSend.component.js
+++ b/client/src/components/messageSend.component.js
@@ -1,8 +1,15 @@
 module.exports = {
   bindings: {
-    user: '<'
+    user: '<',
+    group: '<'
   },
   controller(groups, websockets) {
+    this.$onChanges = (changesObj) => {
+      if (changesObj.group.currentValue) {
+        this.clearInputs();
+      }
+    };
+
     groups.get()
       .then((groupData) => {
         this.groups = groupData;
@@ -12,9 +19,8 @@ module.exports = {
     this.clearInputs = () => {
       this.messageTitle = '';
       this.messageBody = '';
-      this.messageTo = '';
+      this.messageTo = this.user.role === 'organizer' ? '' : [this.group.id];
     };
-    this.clearInputs();
 
     this.sendMessage = () => {
       const toGroupIds = [];
@@ -36,13 +42,13 @@ module.exports = {
     };
   },
   template: `
-    <label for="compose-message-to">To</label>
+    <label for="compose-message-to" ng-if="$ctrl.user.role === 'organizer'">To</label>
     <form ng-submit="$ctrl.sendMessage()">
-      <select id="group-select" class="form-input" required multiple ng-model="$ctrl.messageTo">
+      <select id="group-select" class="form-input" required multiple ng-model="$ctrl.messageTo" ng-if="$ctrl.user.role === 'organizer'">
         <option ng-repeat="group in $ctrl.groups track by group.id" value="{{[group.id, group.name]}}">{{group.name}}</option>
       </select>
-      <label for="compose-message-title">Message Title</label>
-      <input id="compose-message-title" class="form-input" autocomplete="off" ng-model="$ctrl.messageTitle"/>
+      <label for="compose-message-title" ng-if="$ctrl.user.role === 'organizer'">Message Title</label>
+      <input id="compose-message-title" class="form-input" autocomplete="off" ng-model="$ctrl.messageTitle" ng-if="$ctrl.user.role === 'organizer'"/>
       <label for="compose-message-body">Message</label>
       <textarea id="compose-message-body" class="form-input" rows="5" cols="75" autocomplete="off" ng-model="$ctrl.messageBody"></textarea>
       <button>Send</button>

--- a/client/src/components/messageSend.component.js
+++ b/client/src/components/messageSend.component.js
@@ -19,7 +19,7 @@ module.exports = {
     this.clearInputs = () => {
       this.messageTitle = '';
       this.messageBody = '';
-      this.messageTo = this.user.role === 'organizer' ? '' : [this.group.id];
+      this.messageTo = this.user.role === 'organizer' ? '' : [JSON.stringify([this.group.id, this.group.name])];
     };
 
     this.sendMessage = () => {

--- a/client/src/components/staffView.component.js
+++ b/client/src/components/staffView.component.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   template: `
     <group-membership user="$ctrl.user" group="$ctrl.group"></group-membership>
-    <group-updates group="$ctrl.group"></group-updates>
+    <group-updates user="$ctrl.user" group="$ctrl.group"></group-updates>
     <div class="right-sidebar col-md-3">
       <h3>Component for event information</h3>
     </div>


### PR DESCRIPTION
Everyone continues to receive messages from organizer
Messages sent by event staff shows up only for members in the same group

There is a limitation with the current implementation in that if there is more than one organizer, they will not see each other's announcements. I will create a ticket for this refactor -- we probably should put organizers in a group as well.